### PR TITLE
Actually limit normalizers to openreferral format

### DIFF
--- a/src/Normalizer/AddressFieldItemNormalizer.php
+++ b/src/Normalizer/AddressFieldItemNormalizer.php
@@ -18,7 +18,7 @@ class AddressFieldItemNormalizer extends FieldItemNormalizer {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * The interface or class that this Normalizer supports.

--- a/src/Normalizer/ConfigEntityNormalizer.php
+++ b/src/Normalizer/ConfigEntityNormalizer.php
@@ -15,7 +15,7 @@ class ConfigEntityNormalizer extends NormalizerBase {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * {@inheritdoc}

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -17,7 +17,7 @@ class ContentEntityNormalizer extends NormalizerBase {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * {@inheritdoc}

--- a/src/Normalizer/EntityReferenceFieldNormalizer.php
+++ b/src/Normalizer/EntityReferenceFieldNormalizer.php
@@ -16,7 +16,7 @@ class EntityReferenceFieldNormalizer extends NormalizerBase {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * {@inheritdoc}

--- a/src/Normalizer/FieldItemNormalizer.php
+++ b/src/Normalizer/FieldItemNormalizer.php
@@ -20,7 +20,7 @@ class FieldItemNormalizer extends NormalizerBase {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * The interface or class that this Normalizer supports.

--- a/src/Normalizer/GeoFieldItemNormalizer.php
+++ b/src/Normalizer/GeoFieldItemNormalizer.php
@@ -18,7 +18,7 @@ class GeoFieldItemNormalizer extends FieldItemNormalizer {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * The interface or class that this Normalizer supports.

--- a/src/Normalizer/ListNormalizer.php
+++ b/src/Normalizer/ListNormalizer.php
@@ -20,7 +20,7 @@ class ListNormalizer extends SerializerListNormalizer {
    *
    * @var array
    */
-  protected $formats = ['openreferral_json'];
+  protected $format = ['openreferral_json'];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Incorrect property name $formats (vs $format in base class) allowed
our normalizers to run against other serialization formats and muck up
unrelated things.