### PR TITLE
fix: return type hint spacing

### DIFF
--- a/src/Entity/PropertyMapping.php
+++ b/src/Entity/PropertyMapping.php
@@ -107,14 +107,14 @@ class PropertyMapping extends ConfigEntityBase implements PropertyMappingInterfa
   /**
    * {@inheritdoc}
    */
-  public function mappedEntityType():? string {
+  public function mappedEntityType(): ?string {
     return $this->entity_type;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function mappedBundle():? string {
+  public function mappedBundle(): ?string {
     return $this->bundle;
   }
 
@@ -128,7 +128,7 @@ class PropertyMapping extends ConfigEntityBase implements PropertyMappingInterfa
   /**
    * {@inheritdoc}
    */
-  public function getPublicType():? string {
+  public function getPublicType(): ?string {
     return $this->public_type;
   }
 
@@ -142,7 +142,7 @@ class PropertyMapping extends ConfigEntityBase implements PropertyMappingInterfa
   /**
    * {@inheritdoc}
    */
-  public function getPublicDataType():? string {
+  public function getPublicDataType(): ?string {
     return $this->public_datatype;
   }
 

--- a/src/Entity/PropertyMappingInterface.php
+++ b/src/Entity/PropertyMappingInterface.php
@@ -15,7 +15,7 @@ interface PropertyMappingInterface extends ConfigEntityInterface {
    * @return string|null
    *   Entity Type ID. Null if a new unset entity.
    */
-  public function mappedEntityType():? string;
+  public function mappedEntityType(): ?string;
 
   /**
    * Get the mapped entity's bundle id.
@@ -23,7 +23,7 @@ interface PropertyMappingInterface extends ConfigEntityInterface {
    * @return string|null
    *   Bundle ID. Null if a new unset entity.
    */
-  public function mappedBundle():? string;
+  public function mappedBundle(): ?string;
 
   /**
    * Set the Open Referral destination class type.
@@ -41,7 +41,7 @@ interface PropertyMappingInterface extends ConfigEntityInterface {
    * @return string|null
    *   The Open Referral type. Null if a new unset entity.
    */
-  public function getPublicType():? string;
+  public function getPublicType(): ?string;
 
   /**
    * Set the Open Referral destination class data type.
@@ -60,7 +60,7 @@ interface PropertyMappingInterface extends ConfigEntityInterface {
    * @return string|null
    *   The Open Referral data type if one set.
    */
-  public function getPublicDataType():? string;
+  public function getPublicDataType(): ?string;
 
   /**
    * Set the Open Referral field property mapping.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes spacing issues with the return type hint. Getting ahead of these now before the Drupal coding standards change is implemented to check for this.